### PR TITLE
設定保存などが短時間で連続するとロゴ読み込みが無限ループになることがあるのを修正

### DIFF
--- a/EpgTimer/EpgTimer/Common/ChSet5Class.cs
+++ b/EpgTimer/EpgTimer/Common/ChSet5Class.cs
@@ -251,16 +251,20 @@ namespace EpgTimer
         {
             if (Settings.Instance.ShowLogo && LogoList == null)
             {
-                loadLogoTimer = new DispatcherTimer();
-                loadLogoTimer.Tick += (sender, e) =>
+                if (loadLogoTimer == null)
                 {
-                    //2回目以降は間を開ける。
-                    loadLogoTimer.Interval = TimeSpan.FromMilliseconds(500);
-                    if (LoadLogo())
+                    loadLogoTimer = new DispatcherTimer();
+                    loadLogoTimer.Tick += (sender, e) =>
                     {
-                        loadLogoTimer.Stop();
-                    }
-                };
+                        //2回目以降は間を開ける。
+                        loadLogoTimer.Interval = TimeSpan.FromMilliseconds(500);
+                        if (LoadLogo())
+                        {
+                            loadLogoTimer.Stop();
+                        }
+                    };
+                }
+                loadLogoTimer.Interval = TimeSpan.Zero;
                 loadLogoTimer.Start();
             }
         }


### PR DESCRIPTION
EpgTimerSrvの設定保存をきっかけにEpgTimerSrv.exeとEpgTimer.exeが非常に高負荷になったと@tsukumijima氏より報告があって、調べたところロゴの読み込み処理が無限ループになるケースがあるようです。こちらでも再現しました。

（わりと稀だとは思いますが）下のログのようにちょうど `CMD2_EPG_SRV_PROFILE_UPDATE` が短期間で連続すると発生するようで（EpgTimerSrv.exeの設定画面とEpgTimer.exeの設定画面を同時にOKした場合など）、これは`loadLogoTimer`変数の格納する`DispatcherTimer()`オブジェクトが`loadLogoTimer.Stop();`する前に差し替えられたことにより発生していると思われます。

![EpgTimerSrvDebugLog](https://github.com/tkntrec/EDCB/assets/2673799/82147681-d16b-4d32-80a5-ca5a188abf02)
